### PR TITLE
fix CI workflow caching by reordering checkout and setup-go steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,25 +11,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: set up go 1.23
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: set up go
         uses: actions/setup-go@v5
         with:
           go-version: "1.23"
         id: go
 
-      - name: checkout
-        uses: actions/checkout@v4
-
       - name: build and test
         run: |
-          export GO111MODULE=on
-          export TZ="America/Chicago"
-          go get -v
           go test -timeout=60s -v -covermode=count -coverprofile=$GITHUB_WORKSPACE/profile.cov_tmp
           cat $GITHUB_WORKSPACE/profile.cov_tmp | grep -v "_mock.go" > $GITHUB_WORKSPACE/profile.cov
+        env:
+          TZ: "America/Chicago"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,103 +1,95 @@
-linters-settings:
-  govet:
-    shadow: true
-  golint:
-    min-confidence: 0.6
-  gocyclo:
-    min-complexity: 15
-  maligned:
-    suggest-new: true
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: US
-  lll:
-    line-length: 140
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - wrapperFunc
-      - hugeParam
-      - rangeValCopy
-
-linters:
-  disable-all: true
-  enable:
-    - revive
-    - govet
-    - unconvert
-    - gosec
-    - unparam
-    - unused
-    - typecheck
-    - ineffassign
-    - stylecheck
-    - gochecknoinits
-    - gocritic
-    - nakedret
-    - gosimple
-    - prealloc
-
-  fast: false
-
-
+version: "2"
 run:
   concurrency: 4
-
-issues:
-  exclude-dirs:
-    - vendor
-  exclude-rules:
-    - text: "should have a package comment, unless it's in another file for this package"
-      linters:
-        - golint
-    - text: "exitAfterDefer:"
-      linters:
-        - gocritic
-    - text: "whyNoLint: include an explanation for nolint directive"
-      linters:
-        - gocritic
-    - text: "go.mongodb.org/mongo-driver/bson/primitive.E"
-      linters:
-        - govet
-    - text: "weak cryptographic primitive"
-      linters:
-        - gosec
-    - text: "integer overflow conversion"
-      linters:
-        - gosec
-    - text: "should have a package comment"
-      linters:
-        - revive
-    - text: "at least one file in a package should have a package comment"
-      linters:
-        - stylecheck
-    - text: "commentedOutCode: may want to remove commented-out code"
-      linters:
-        - gocritic
-    - text: "unnamedResult: consider giving a name to these results"
-      linters:
-        - gocritic
-    - text: "var-naming: don't use an underscore in package name"
-      linters:
-        - revive
-    - text: "should not use underscores in package names"
-      linters:
-        - stylecheck
-    - text: "struct literal uses unkeyed fields"
-      linters:
-        - govet
-    - linters:
-        - unparam
-        - unused
-        - revive
-      path: _test\.go$
-      text: "unused-parameter"
-  exclude-use-default: false
-
+linters:
+  default: none
+  enable:
+    - gochecknoinits
+    - gocritic
+    - gosec
+    - govet
+    - ineffassign
+    - nakedret
+    - prealloc
+    - revive
+    - unconvert
+    - unparam
+    - unused
+  settings:
+    dupl:
+      threshold: 100
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+        - hugeParam
+        - rangeValCopy
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+    gocyclo:
+      min-complexity: 15
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - gocritic
+        text: 'exitAfterDefer:'
+      - linters:
+          - gocritic
+        text: 'whyNoLint: include an explanation for nolint directive'
+      - linters:
+          - govet
+        text: go.mongodb.org/mongo-driver/bson/primitive.E
+      - linters:
+          - gosec
+        text: weak cryptographic primitive
+      - linters:
+          - gosec
+        text: integer overflow conversion
+      - linters:
+          - revive
+        text: should have a package comment
+      - linters:
+          - staticcheck
+        text: at least one file in a package should have a package comment
+      - linters:
+          - gocritic
+        text: 'commentedOutCode: may want to remove commented-out code'
+      - linters:
+          - gocritic
+        text: 'unnamedResult: consider giving a name to these results'
+      - linters:
+          - revive
+        text: 'var-naming: don''t use an underscore in package name'
+      - linters:
+          - staticcheck
+        text: should not use underscores in package names
+      - linters:
+          - govet
+        text: struct literal uses unkeyed fields
+      - linters:
+          - revive
+          - unparam
+          - unused
+        path: _test\.go$
+        text: unused-parameter
+    paths:
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
## Summary
- Move checkout step before setup-go to enable proper Go module caching
- Update actions/checkout to v4 and actions/setup-go to v5
- Update golangci-lint-action to v7 with latest version